### PR TITLE
AP-64_email-reminder

### DIFF
--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -27,7 +27,7 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
 
     @TestVisible
     private static List<Event> getListOfUpcomingInterviewEventsInNDays(Integer nextNDays) {
-        String queryString = 'SELECT Id, Location, OwnerId, StartDateTime,Subject FROM Event WHERE RecordType.Name = \'Interview\' AND StartDateTime = NEXT_N_DAYS:' + nextNDays + ' ORDER BY StartDateTime ASC NULLS LAST WITH SYSTEM_MODE';
+        String queryString = 'SELECT Id, Location, OwnerId, StartDateTime,Subject FROM Event WHERE RecordType.Name = \'Interview\' AND StartDateTime = NEXT_N_DAYS:' + nextNDays + ' ORDER BY StartDateTime ASC NULLS LAST';
         return Database.query(queryString);
     }
 

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,58 +1,18 @@
 
 public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
     public void execute(SchedulableContext ctx) {
-        sendDailyInterviewEmailReminders();
-        // // query for interview events with a start date tomorrow
-        // List<Event> interviewsTomorrow = [
-        //     SELECT 
-        //         Id,
-        //         Location,
-        //         OwnerId, 
-        //         StartDateTime,
-        //         Subject
-        //     FROM Event 
-        //     WHERE 
-        //         RecordType.Name = 'Interview' 
-        //         AND StartDateTime = NEXT_N_DAYS:1
-        //     WITH SYSTEM_MODE
-        // ];
-
-        // if (!interviewsTomorrow.isEmpty()) {
-        //     Map<Id, List<Event>> ownerIdToListOfInterviewsTomorrowMap = generateMapOfOwnerIdsToInterviews(interviewsTomorrow);
-        //     List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();
-        //     for (Id ownerId : ownerIdToListOfInterviewsTomorrowMap.keySet()) {
-        //         Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfInterviewsTomorrowMap.get(ownerId));
-        //         emailsToSendOut.add(emailToSend);
-        //     }
-        //     try {
-        //         Messaging.sendEmail(emailsToSendOut);
-        //     } catch (Exception ex) {
-        //         System.debug('Error sending email: ' + ex.getMessage());
-        //     } 
-        // }
-
+        sendDailyInterviewEmailReminders(1);
     }
     @TestVisible
-    private static void sendDailyInterviewEmailReminders() {
-        List<Event> interviewsTomorrow = [
-            SELECT 
-                Id,
-                Location,
-                OwnerId, 
-                StartDateTime,
-                Subject
-            FROM Event 
-            WHERE 
-                RecordType.Name = 'Interview' 
-                AND StartDateTime = NEXT_N_DAYS:1
-            WITH SYSTEM_MODE
-        ];
+    private static void sendDailyInterviewEmailReminders(Integer nextNDays) {
+        String queryString = 'SELECT Id, Location, OwnerId, StartDateTime,Subject FROM Event WHERE RecordType.Name = \'Interview\' AND StartDateTime = NEXT_N_DAYS:' + nextNDays + ' WITH SYSTEM_MODE';
+        List<Event> upcomingInterviewList = Database.query(queryString);
 
-        if (!interviewsTomorrow.isEmpty()) {
-            Map<Id, List<Event>> ownerIdToListOfInterviewsTomorrowMap = generateMapOfOwnerIdsToInterviews(interviewsTomorrow);
+        if (!upcomingInterviewList.isEmpty()) {
+            Map<Id, List<Event>> ownerIdToListOfUpcomingInterviewsMap = generateMapOfOwnerIdsToInterviews(upcomingInterviewList);
             List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();
-            for (Id ownerId : ownerIdToListOfInterviewsTomorrowMap.keySet()) {
-                Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfInterviewsTomorrowMap.get(ownerId));
+            for (Id ownerId : ownerIdToListOfUpcomingInterviewsMap.keySet()) {
+                Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfUpcomingInterviewsMap.get(ownerId));
                 emailsToSendOut.add(emailToSend);
             }
             try {
@@ -67,7 +27,7 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
     private static Messaging.SingleEmailMessage generateEmail(Id ownerId, List<Event> ownerTasks) {
         Messaging.SingleEmailMessage newEmail = new Messaging.SingleEmailMessage();
         String eventTableHTML = generateEventTable(ownerTasks);
-        newEmail.setSubject('Interview Events Tomorrow: ' + Date.today().addDays(1));
+        newEmail.setSubject('Interview Events Upcoming');
         newEmail.setHtmlBody(eventTableHTML);
         newEmail.setToAddresses(new String[] {ownerId});
         return newEmail;
@@ -97,7 +57,6 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
         }
         return interviewsByOwnerId;
     } 
-
 }
 
 /*

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,40 +1,69 @@
 public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
     public void execute(SchedulableContext ctx) {
+        // query for interview events with a start date tomorrow
         List<Event> interviewsTomorrow = [
             SELECT 
                 Id,
                 Location,
-                WhatId.Name, 
+                OwnerId, 
                 StartDateTime 
             FROM Event 
             WHERE 
                 RecordType.Name = 'Interview' 
                 AND StartDateTime = NEXT_N_DAYS:1
         ];
-        if (!interviewsTomorrow.isEmpty()) {
-            String eventTableHTML = generateEventTable(interviewsTomorrow);
-            Messaging.SingleEmailMessage newEmail = new Messaging.SingleEmailMessage();
-            newEmail.setSubject('Interview Events Tomorrow');
-            newEmail.setHtmlBody(eventTableHTML);
-            newEmail.setToAddresses(new String[] {'recipient@example.com'});    // need to account for OwnerId
 
-            Messaging.sendEmail(new Messaging.SingleEmailMessage[] { newEmail });
+        // if the query returns results, map the ownerId to a list of events, generate emails of all events for each ownerId and add to a list of emails to send out
+        if (!interviewsTomorrow.isEmpty()) {
+            Map<Id, List<Event>> ownerIdToListOfInterviewsTomorrowMap = generateMapOfOwnerIdsToInterviews(interviewsTomorrow);
+            List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();
+            for (Id ownerId : ownerIdToListOfInterviewsTomorrowMap.keySet()) {
+                Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfInterviewsTomorrowMap.get(ownerId));
+                emailsToSendOut.add(emailToSend);
+            }
+            try {
+                Messaging.sendEmail(emailsToSendOut);
+            } catch (Exception ex) {
+                System.debug('Error sending email: ' + ex.getMessage());
+            } 
         }
     }
 
+    @TestVisible
+    private static Messaging.SingleEmailMessage generateEmail(Id ownerId, List<Event> ownerTasks) {
+        Messaging.SingleEmailMessage newEmail = new Messaging.SingleEmailMessage();
+        String eventTableHTML = generateEventTable(ownerTasks);
+        newEmail.setSubject('Interview Events Tomorrow: ' + Date.today().addDays(1));
+        newEmail.setHtmlBody(eventTableHTML);
+        newEmail.setToAddresses(new String[] {ownerId});
+        return newEmail;
+    }
+    @TestVisible
     private static String generateEventTable(List<Event> events) {
         String tableHTML = '<table border="1"><tr><th>Location</th><th>Appointment</th><th>Start</th></tr>';
         for(Event evt : events) {
             tableHTML += '<tr>';
             tableHTML += '<td>' + evt.Location + '</td>';
+            tableHTML += '<td>' + evt.Subject + '</td>';
             tableHTML += '<td>' + evt.StartDateTime.format('yyyy-MM-dd HH:mm:ss') + '</td>';
-            tableHTML += '<td>' + evt.WhatId.Name + '</td>';
             tableHTML += '</tr>';
         }
         tableHTML += '</table>';
         
         return tableHTML;
     }
+    @TestVisible
+    private static Map<Id, List<Event>> generateMapOfOwnerIdsToInterviews(List<Event> events) {
+        Map<Id, List<Event>> interviewsByOwnerId = new Map<Id, List<Event>>();
+        for (Event event : events) {
+            if (!interviewsByOwnerId.containsKey(event.OwnerId)) {
+                interviewsByOwnerId.put(event.OwnerId, new List<Event>());
+            }
+            interviewsByOwnerId.get(event.OwnerId).add(event);
+        }
+        return interviewsByOwnerId;
+    } 
+
 }
 
 /*

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -17,6 +17,8 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
             }
             try {
                 Messaging.sendEmail(emailsToSendOut);
+                // assert email limit ticks up by 1
+                // manually go trigger email to send to visual test
             } catch (Exception ex) {
                 System.debug('Error sending email: ' + ex.getMessage());
             } 

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -6,7 +6,8 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
                 Id,
                 Location,
                 OwnerId, 
-                StartDateTime 
+                StartDateTime,
+                Subject
             FROM Event 
             WHERE 
                 RecordType.Name = 'Interview' 

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,0 +1,11 @@
+public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
+    public void execute(SchedulableContext ctx) {
+        
+    }
+}
+
+/*
+// Schedule the job to run daily at 6 AM
+String cronExpression = '0 0 6 * * ?';
+System.schedule('DailyScheduledJob', cronExpression, new DailyScheduledJob());
+*/

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,6 +1,39 @@
 public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
     public void execute(SchedulableContext ctx) {
+        List<Event> interviewsTomorrow = [
+            SELECT 
+                Id,
+                Location,
+                WhatId.Name, 
+                StartDateTime 
+            FROM Event 
+            WHERE 
+                RecordType.Name = 'Interview' 
+                AND StartDateTime = NEXT_N_DAYS:1
+        ];
+        if (!interviewsTomorrow.isEmpty()) {
+            String eventTableHTML = generateEventTable(interviewsTomorrow);
+            Messaging.SingleEmailMessage newEmail = new Messaging.SingleEmailMessage();
+            newEmail.setSubject('Interview Events Tomorrow');
+            newEmail.setHtmlBody(eventTableHTML);
+            newEmail.setToAddresses(new String[] {'recipient@example.com'});    // need to account for OwnerId
+
+            Messaging.sendEmail(new Messaging.SingleEmailMessage[] { newEmail });
+        }
+    }
+
+    private static String generateEventTable(List<Event> events) {
+        String tableHTML = '<table border="1"><tr><th>Location</th><th>Appointment</th><th>Start</th></tr>';
+        for(Event evt : events) {
+            tableHTML += '<tr>';
+            tableHTML += '<td>' + evt.Location + '</td>';
+            tableHTML += '<td>' + evt.StartDateTime.format('yyyy-MM-dd HH:mm:ss') + '</td>';
+            tableHTML += '<td>' + evt.WhatId.Name + '</td>';
+            tableHTML += '</tr>';
+        }
+        tableHTML += '</table>';
         
+        return tableHTML;
     }
 }
 

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -3,6 +3,7 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
     public void execute(SchedulableContext ctx) {
         sendDailyInterviewEmailReminders(3);
     }
+    
     @TestVisible
     private static void sendDailyInterviewEmailReminders(Integer nextNDays) {
         List<Event> upcomingInterviewsList = getListOfUpcomingInterviewEventsInNDays(nextNDays);

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,6 +1,39 @@
+
 public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
     public void execute(SchedulableContext ctx) {
-        // query for interview events with a start date tomorrow
+        sendDailyInterviewEmailReminders();
+        // // query for interview events with a start date tomorrow
+        // List<Event> interviewsTomorrow = [
+        //     SELECT 
+        //         Id,
+        //         Location,
+        //         OwnerId, 
+        //         StartDateTime,
+        //         Subject
+        //     FROM Event 
+        //     WHERE 
+        //         RecordType.Name = 'Interview' 
+        //         AND StartDateTime = NEXT_N_DAYS:1
+        //     WITH SYSTEM_MODE
+        // ];
+
+        // if (!interviewsTomorrow.isEmpty()) {
+        //     Map<Id, List<Event>> ownerIdToListOfInterviewsTomorrowMap = generateMapOfOwnerIdsToInterviews(interviewsTomorrow);
+        //     List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();
+        //     for (Id ownerId : ownerIdToListOfInterviewsTomorrowMap.keySet()) {
+        //         Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfInterviewsTomorrowMap.get(ownerId));
+        //         emailsToSendOut.add(emailToSend);
+        //     }
+        //     try {
+        //         Messaging.sendEmail(emailsToSendOut);
+        //     } catch (Exception ex) {
+        //         System.debug('Error sending email: ' + ex.getMessage());
+        //     } 
+        // }
+
+    }
+    @TestVisible
+    private static void sendDailyInterviewEmailReminders() {
         List<Event> interviewsTomorrow = [
             SELECT 
                 Id,
@@ -12,9 +45,9 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
             WHERE 
                 RecordType.Name = 'Interview' 
                 AND StartDateTime = NEXT_N_DAYS:1
+            WITH SYSTEM_MODE
         ];
 
-        // if the query returns results, map the ownerId to a list of events, generate emails of all events for each ownerId and add to a list of emails to send out
         if (!interviewsTomorrow.isEmpty()) {
             Map<Id, List<Event>> ownerIdToListOfInterviewsTomorrowMap = generateMapOfOwnerIdsToInterviews(interviewsTomorrow);
             List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls
@@ -1,15 +1,14 @@
 
 public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable {
     public void execute(SchedulableContext ctx) {
-        sendDailyInterviewEmailReminders(1);
+        sendDailyInterviewEmailReminders(3);
     }
     @TestVisible
     private static void sendDailyInterviewEmailReminders(Integer nextNDays) {
-        String queryString = 'SELECT Id, Location, OwnerId, StartDateTime,Subject FROM Event WHERE RecordType.Name = \'Interview\' AND StartDateTime = NEXT_N_DAYS:' + nextNDays + ' WITH SYSTEM_MODE';
-        List<Event> upcomingInterviewList = Database.query(queryString);
+        List<Event> upcomingInterviewsList = getListOfUpcomingInterviewEventsInNDays(nextNDays);
 
-        if (!upcomingInterviewList.isEmpty()) {
-            Map<Id, List<Event>> ownerIdToListOfUpcomingInterviewsMap = generateMapOfOwnerIdsToInterviews(upcomingInterviewList);
+        if (!upcomingInterviewsList.isEmpty()) {
+            Map<Id, List<Event>> ownerIdToListOfUpcomingInterviewsMap = generateOwnerIdToInterviewsMap(upcomingInterviewsList);
             List<Messaging.SingleEmailMessage> emailsToSendOut = new List<Messaging.SingleEmailMessage>();
             for (Id ownerId : ownerIdToListOfUpcomingInterviewsMap.keySet()) {
                 Messaging.SingleEmailMessage emailToSend = generateEmail(ownerId, ownerIdToListOfUpcomingInterviewsMap.get(ownerId));
@@ -23,6 +22,12 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
                 System.debug('Error sending email: ' + ex.getMessage());
             } 
         }
+    }
+
+    @TestVisible
+    private static List<Event> getListOfUpcomingInterviewEventsInNDays(Integer nextNDays) {
+        String queryString = 'SELECT Id, Location, OwnerId, StartDateTime,Subject FROM Event WHERE RecordType.Name = \'Interview\' AND StartDateTime = NEXT_N_DAYS:' + nextNDays + ' ORDER BY StartDateTime ASC NULLS LAST WITH SYSTEM_MODE';
+        return Database.query(queryString);
     }
 
     @TestVisible
@@ -49,7 +54,7 @@ public with sharing class UpcomingInterviewEmail_Schedule implements Schedulable
         return tableHTML;
     }
     @TestVisible
-    private static Map<Id, List<Event>> generateMapOfOwnerIdsToInterviews(List<Event> events) {
+    private static Map<Id, List<Event>> generateOwnerIdToInterviewsMap(List<Event> events) {
         Map<Id, List<Event>> interviewsByOwnerId = new Map<Id, List<Event>>();
         for (Event event : events) {
             if (!interviewsByOwnerId.containsKey(event.OwnerId)) {

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls-meta.xml
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -21,25 +21,94 @@
  */
 @isTest
 private class UpcomingInterviewEmail_Schedule_Test {
+    private static final Integer NUMBER_OF_TEST_INTERVIEWS_TOMORROW = 5;
+    private static final Id INTERVIEW_EVENT_RECORDTYPE_ID = [
+        SELECT Id, Name 
+        FROM RecordType 
+        WHERE SobjectType = 'Event' AND Name = 'Interview' 
+        LIMIT 1
+    ].Id;
+    private static final Integer HEADER_ROW = 1;
 
     @isTest
-    static void myUnitTest() {
-        Integer numRecordsToGenerate = 5;
-        List<Event> testInterviewEvents = new List<Event>();
-        for (Integer i = 0; i < numRecordsToGenerate; i++) {
-            Event newEvent = new Event();
-            newEvent.RecordType.Name = 'Interview';
-            newEvent.Subject = 'Interview' + i;
-            newEvent.StartDateTime = Datetime.now().addDays(1);
-            newEvent.EndDateTime = newEvent.StartDateTime.addMinutes(30);
-            newEvent.OwnerId = UserInfo.getUserId();
-            testInterviewEvents.add(newEvent);
-        }
-        insert testInterviewEvents;
+    static void upcomingInterviewEmailTest() {
+        User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
+        List<Event> eventsTomorrowList = [
+            SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId
+            FROM Event
+            WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID
+            AND StartDateTime = NEXT_N_DAYS:1
+        ];
+
         Test.startTest();
-        // schedule the email reminder
+        Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUser.Id, eventsTomorrowList);
         Test.stopTest();
 
-        // assert
+        // emails are generated as expected
+        Assert.areEqual(
+            NUMBER_OF_TEST_INTERVIEWS_TOMORROW + HEADER_ROW, 
+            resultEmail.getHtmlBody().countMatches('<tr>'), 
+            'The number of interview rows in the email should match the number of interviews tomorrow.'
+        );
+        Assert.isTrue(resultEmail.toaddresses.contains(testUser.Id), 'Email is missing user in To: field');
+        Assert.isTrue(resultEmail.getSubject().contains('Interview Events Tomorrow:'));
+    }
+    @isTest
+    private static void testGenerateEventTable() {
+        User user = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
+        List<Event> testEvents = [SELECT Id, StartDateTime, EndDateTime, OwnerId, Subject, Location FROM Event];
+        Map<Id, List<Event>> ownerIdToEventsMap = new Map<Id, List<Event>>();
+        
+        Test.startTest();
+        String eventTable = UpcomingInterviewEmail_Schedule.generateEventTable(testEvents);
+        Test.stopTest();
+
+        Assert.IsTrue(eventTable.contains('<td>Online</td><td>Test Interview 1</td>'), 'Expected HTML table to output');
+    }
+
+    @isTest 
+    static void generateMapOfOwnerIdsToInterviews_Test_shouldPass() {
+        User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
+        List<Event> events = [SELECT Id, OwnerId FROM Event];
+
+        Test.startTest();
+        Map<Id, List<Event>> resultsMap = UpcomingInterviewEmail_Schedule.generateMapOfOwnerIdsToInterviews(events);
+        Test.stopTest();
+
+        Assert.areEqual(NUMBER_OF_TEST_INTERVIEWS_TOMORROW, resultsMap.get((Id)testUser.Id).size(), 'expected events to be associated with the user that matched test constant');
+    }
+
+    @TestSetup
+    static void makeData(){
+        Profile profile = [SELECT Id FROM Profile WHERE Name='Standard User']; 
+        String uniqueString = String.valueOf(DateTime.now().getTime());
+        User testUser = new User(
+            Alias = 'testUser',
+            Username = 'testUser' + uniqueString + '@test.com',
+            Email = 'testUser' + uniqueString + '@test.com',
+            LastName = 'testUser' + uniqueString,
+            ProfileId = profile.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            LocaleSidKey = 'en_US',
+            LanguageLocaleKey = 'en_US',
+            EmailEncodingKey = 'UTF-8'
+        );
+        insert testUser;
+
+        RecordType interviewEventRecordType = [SELECT Id, Name FROM RecordType WHERE SobjectType='Event' AND Name='Interview'];
+
+        List<Event> events = new List<Event>();
+        for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_TOMORROW; i++) {
+            Event newEvent = new Event(
+                Subject = 'Test Interview ' + i,
+                StartDateTime = DateTime.now().addDays(1),
+                EndDateTime = Datetime.now().addDays(1).addMinutes(30),
+                Location = 'Online',
+                OwnerId = testUser.Id,
+                RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
+            );
+            events.add(newEvent);
+        }
+        insert events;
     }
 }

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -1,0 +1,29 @@
+/**
+ * This class contains unit tests for validating the behavior of Apex classes
+ * and triggers.
+ *
+ * Unit tests are class methods that verify whether a particular piece
+ * of code is working properly. Unit test methods take no arguments,
+ * commit no data to the database, and are flagged with the testMethod
+ * keyword in the method definition.
+ *
+ * All test methods in an org are executed whenever Apex code is deployed
+ * to a production org to confirm correctness, ensure code
+ * coverage, and prevent regressions. All Apex classes are
+ * required to have at least 75% code coverage in order to be deployed
+ * to a production org. In addition, all triggers must have some code coverage.
+ * 
+ * The @isTest class annotation indicates this class only contains test
+ * methods. Classes defined with the @isTest annotation do not count against
+ * the org size limit for all Apex scripts.
+ *
+ * See the Apex Language Reference for more information about Testing and Code Coverage.
+ */
+@isTest
+private class UpcomingInterviewEmail_Schedule_Test {
+
+    @isTest
+    static void myUnitTest() {
+        // TO DO: implement unit test
+    }
+}

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -24,6 +24,22 @@ private class UpcomingInterviewEmail_Schedule_Test {
 
     @isTest
     static void myUnitTest() {
-        // TO DO: implement unit test
+        Integer numRecordsToGenerate = 5;
+        List<Event> testInterviewEvents = new List<Event>();
+        for (Integer i = 0; i < numRecordsToGenerate; i++) {
+            Event newEvent = new Event();
+            newEvent.RecordType.Name = 'Interview';
+            newEvent.Subject = 'Interview' + i;
+            newEvent.StartDateTime = Datetime.now().addDays(1);
+            newEvent.EndDateTime = newEvent.StartDateTime.addMinutes(30);
+            newEvent.OwnerId = UserInfo.getUserId();
+            testInterviewEvents.add(newEvent);
+        }
+        insert testInterviewEvents;
+        Test.startTest();
+        // schedule the email reminder
+        Test.stopTest();
+
+        // assert
     }
 }

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -45,23 +45,8 @@ private class UpcomingInterviewEmail_Schedule_Test {
     //         6, 0, 0
     //     );
 
-    //     List<Event> interviewsTomorrow = [
-    //         SELECT 
-    //             Id,
-    //             Location,
-    //             OwnerId, 
-    //             StartDateTime,
-    //             Subject
-    //         FROM Event 
-    //         WHERE 
-    //             RecordType.Name = 'Interview' 
-    //             AND StartDateTime = NEXT_N_DAYS:1
-    //     ];
+    //     generateInterviewsFromUserIdTestData(generateUserTestData());
 
-    //     for (Event event : interviewsTomorrow) {
-    //         event.OwnerId = null;
-    //     }
-    //     update interviewsTomorrow;
 
     //     UpcomingInterviewEmail_Schedule scheduleJob = new UpcomingInterviewEmail_Schedule();
 
@@ -86,32 +71,55 @@ private class UpcomingInterviewEmail_Schedule_Test {
     //     Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
     // }
 
-    // @isTest 
-    // private static List<User> generateUserTestData() {
-    //     List<Profile> standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
-
-    //     List<User> users = new List<User>();
-    //     String uniqueString = String.valueOf(DateTime.now().getTime());
-    //     List<User> testUsers = new List<User>();
-    //     for(Integer i = 0; i < 15; i++) {
-    //         User u = new User(
-    //             LastName = 'TestUser' + i,
-    //             FirstName = 'FirstName' + i,
-    //             Email = 'testuser' + i + '@example.com',
-    //             Username = 'testuser' + i + '@example.com',
-    //             Alias = 'TUser' + i,
-    //             ProfileId = '005XXXXXXXXXXXX', // Replace with the desired Profile Id
-    //             TimeZoneSidKey = 'America/Los_Angeles',
-    //             LocaleSidKey = 'en_US',
-    //             EmailEncodingKey = 'UTF-8',
-    //             LanguageLocaleKey = 'en_US',
-    //             IsActive = true
-    //         );
-    //         testUsers.add(u);
-    //     }
+    @isTest 
+    private static List<User> generateUserTestData() {
+        Id standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1].Id;
+        final Integer NUM_USERS_TO_CREATE = 51;
         
-    //     insert testUsers;
+        List<User> users = new List<User>();
+        String uniqueString = String.valueOf(DateTime.now().getTime());
+        List<User> testUsers = new List<User>();
+        for(Integer i = 0; i < NUM_USERS_TO_CREATE; i++) {
+            User user = new User(
+                LastName = 'TestUser' + i,
+                FirstName = 'FirstName' + i,
+                Email = 'testuser' + i + uniqueString + '@example.com',
+                Username = 'testuser' + i + uniqueString + '@example.com',
+                Alias = 'TUser' + i,
+                ProfileId = standardProfileId,
+                TimeZoneSidKey = 'America/Los_Angeles',
+                LocaleSidKey = 'en_US',
+                EmailEncodingKey = 'UTF-8',
+                LanguageLocaleKey = 'en_US',
+                IsActive = true
+            );
+            testUsers.add(user);
+        }
+        
+        insert testUsers;
+        return testUsers;
+    }
+    // @isTest 
+    // private static List<Event> generateInterviewsFromUserIdTestData(List<Id> testUserIds) {
+    //     List<Event> events = new List<Event>();
+
+    //     for (Id testUserId : testUserIds) {
+    //         for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_TOMORROW; i++) {
+    //             Event newEvent = new Event(
+    //                 Subject = 'Test Interview ' + i,
+    //                 StartDateTime = DateTime.now().addDays(1),
+    //                 EndDateTime = Datetime.now().addDays(1).addMinutes(30),
+    //                 Location = 'Online',
+    //                 OwnerId = testUserId,
+    //                 RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
+    //             );
+    //             events.add(newEvent);
+    //         }
+    //     }
+    //     insert events;
     // }
+
+
 
     @isTest
     static void upcomingInterviewEmailGeneration_Test() {
@@ -172,7 +180,6 @@ private class UpcomingInterviewEmail_Schedule_Test {
         User testUser = new User(
             Alias = 'testUser',
             Username = 'testUser' + uniqueString + '@test.com',
-            // Email = 'testUser' + uniqueString + '@test.com',
             Email = EMAIL_TARGET_FOR_TEST,
             LastName = 'testUser' + uniqueString,
             ProfileId = standardUserProfile.Id,
@@ -182,8 +189,6 @@ private class UpcomingInterviewEmail_Schedule_Test {
             EmailEncodingKey = 'UTF-8'
         );
         insert testUser;
-
-        RecordType interviewEventRecordType = [SELECT Id, Name FROM RecordType WHERE SobjectType='Event' AND Name='Interview'];
 
         List<Event> events = new List<Event>();
         for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_TOMORROW; i++) {

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -138,18 +138,18 @@ private class UpcomingInterviewEmail_Schedule_Test {
         
         Test.startTest();
         UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders(NUMBER_OF_TEST_INTERVIEWS_UPCOMING);
-        Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
+        Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single email call to be invoked');
         Test.stopTest();
 
         List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
-        System.assertEquals(NUM_USERS_TO_CREATE, sentEmails.size(), 'Expected 1 email to be sent');
+        System.assertEquals(NUM_USERS_TO_CREATE, sentEmails.size(), 'Expected 3 emails to be sent');
     }
 
     @isTest
     static void scheduleExecute_Test_shouldSchedule() {
         Test.startTest();
         String jobId = System.schedule('UpcomingInterviewEmail_Schedule Job', DAILY_6AM, new UpcomingInterviewEmail_Schedule());
-        // Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
+
         CronTrigger ct = [
             SELECT Id, CronExpression, TimesTriggered, NextFireTime
             FROM CronTrigger 

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -71,34 +71,34 @@ private class UpcomingInterviewEmail_Schedule_Test {
     //     Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
     // }
 
-    @isTest 
-    private static List<User> generateUserTestData() {
-        Id standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1].Id;
-        final Integer NUM_USERS_TO_CREATE = 51;
+    // @isTest 
+    // private static List<User> generateUserTestData() {
+    //     Id standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1].Id;
+    //     final Integer NUM_USERS_TO_CREATE = 51;
         
-        List<User> users = new List<User>();
-        String uniqueString = String.valueOf(DateTime.now().getTime());
-        List<User> testUsers = new List<User>();
-        for(Integer i = 0; i < NUM_USERS_TO_CREATE; i++) {
-            User user = new User(
-                LastName = 'TestUser' + i,
-                FirstName = 'FirstName' + i,
-                Email = 'testuser' + i + uniqueString + '@example.com',
-                Username = 'testuser' + i + uniqueString + '@example.com',
-                Alias = 'TUser' + i,
-                ProfileId = standardProfileId,
-                TimeZoneSidKey = 'America/Los_Angeles',
-                LocaleSidKey = 'en_US',
-                EmailEncodingKey = 'UTF-8',
-                LanguageLocaleKey = 'en_US',
-                IsActive = true
-            );
-            testUsers.add(user);
-        }
+    //     List<User> users = new List<User>();
+    //     String uniqueString = String.valueOf(DateTime.now().getTime());
+    //     List<User> testUsers = new List<User>();
+    //     for(Integer i = 0; i < NUM_USERS_TO_CREATE; i++) {
+    //         User user = new User(
+    //             LastName = 'TestUser' + i,
+    //             FirstName = 'FirstName' + i,
+    //             Email = 'testuser' + i + uniqueString + '@example.com',
+    //             Username = 'testuser' + i + uniqueString + '@example.com',
+    //             Alias = 'TUser' + i,
+    //             ProfileId = standardProfileId,
+    //             TimeZoneSidKey = 'America/Los_Angeles',
+    //             LocaleSidKey = 'en_US',
+    //             EmailEncodingKey = 'UTF-8',
+    //             LanguageLocaleKey = 'en_US',
+    //             IsActive = true
+    //         );
+    //         testUsers.add(user);
+    //     }
         
-        insert testUsers;
-        return testUsers;
-    }
+    //     insert testUsers;
+    //     return testUsers;
+    // }
     // @isTest 
     // private static List<Event> generateInterviewsFromUserIdTestData(List<Id> testUserIds) {
     //     List<Event> events = new List<Event>();
@@ -203,5 +203,16 @@ private class UpcomingInterviewEmail_Schedule_Test {
             events.add(newEvent);
         }
         insert events;
+    }
+@isTest
+    private static void testSendDailyInterviewEmailReminders() {
+
+        Test.startTest();
+        UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders();
+        Test.stopTest();
+
+        List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
+        System.assertEquals(1, sentEmails.size(), 'Expected 1 email to be sent');
+        System.assertEquals('1 upcoming interview tomorrow', sentEmails[0].Subject, 'Email subject is incorrect');
     }
 }

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -10,7 +10,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
     ].Id;
     private static final Integer HEADER_ROW = 1;
     private static final String DAILY_6AM = '0 0 6 * * ?';
-    private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + String.valueOf(DateTime.now().getTime()) + '@test.com';
+    private static final String CURRENT_USER_EMAIL_TARGET = UserInfo.getUserEmail();
     private static final Integer LOOK_AHEAD_NEXT_N_DAYS = 1;
 
     @TestSetup
@@ -23,7 +23,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
             User testUser = new User(
                 Alias = 'TUser' + i,
                 Username = 'testuser' + i + uniqueString + '@example.com',
-                Email = EMAIL_TARGET_FOR_TEST,
+                Email = CURRENT_USER_EMAIL_TARGET,
                 LastName = 'TestUser' + i,
                 ProfileId = standardUserProfile.Id,
                 TimeZoneSidKey = 'America/Los_Angeles',

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -10,7 +10,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
     ].Id;
     private static final Integer HEADER_ROW = 1;
     private static final String DAILY_6AM = '0 0 6 * * ?';
-    private static final String CURRENT_USER_EMAIL_TARGET = UserInfo.getUserEmail();
+    private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + String.valueOf(DateTime.now().getTime()) + '@test.com';
     private static final Integer LOOK_AHEAD_NEXT_N_DAYS = 1;
 
     @TestSetup
@@ -23,7 +23,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
             User testUser = new User(
                 Alias = 'TUser' + i,
                 Username = 'testuser' + i + uniqueString + '@example.com',
-                Email = CURRENT_USER_EMAIL_TARGET,
+                Email = EMAIL_TARGET_FOR_TEST,
                 LastName = 'TestUser' + i,
                 ProfileId = standardUserProfile.Id,
                 TimeZoneSidKey = 'America/Los_Angeles',

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -8,10 +8,50 @@ private class UpcomingInterviewEmail_Schedule_Test {
         LIMIT 1
     ].Id;
     private static final Integer HEADER_ROW = 1;
-    // Schedule the job to run daily at 6 AM
     private static final String DAILY_6AM = '0 0 6 * * ?';
     private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + String.valueOf(DateTime.now().getTime()) + '@test.com';
-    private static final Integer LOOK_AHEAD_NEXT_N_DAYS = 3;
+    private static final Integer LOOK_AHEAD_NEXT_N_DAYS = 1;
+
+    @TestSetup
+    static void makeData(){
+        // generate users, to attach jobs to
+        final Integer NUM_USERS_TO_CREATE = 3;
+        Profile standardUserProfile = [SELECT Id FROM Profile WHERE Name='Standard User' LIMIT 1]; 
+        String uniqueString = String.valueOf(DateTime.now().getTime());
+        List<User> testUsers = new List<User>();
+        for(Integer i = 0; i < NUM_USERS_TO_CREATE; i++) {
+            User testUser = new User(
+                Alias = 'TUser' + i,
+                Username = 'testuser' + i + uniqueString + '@example.com',
+                Email = EMAIL_TARGET_FOR_TEST,
+                LastName = 'TestUser' + i,
+                ProfileId = standardUserProfile.Id,
+                TimeZoneSidKey = 'America/Los_Angeles',
+                LocaleSidKey = 'en_US',
+                LanguageLocaleKey = 'en_US',
+                EmailEncodingKey = 'UTF-8',
+                IsActive = true
+            );
+            testUsers.add(testUser);
+        }
+        insert testUsers;
+
+        List<Event> events = new List<Event>();
+        for (User testUser : testUsers) {
+            for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_UPCOMING; i++) {
+                Event newEvent = new Event(
+                    Subject = 'Test Interview ' + i,
+                    StartDateTime = DateTime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS),
+                    EndDateTime = Datetime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS).addMinutes(30),
+                    Location = 'Online',
+                    OwnerId = testUser.Id,
+                    RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
+                );
+                events.add(newEvent);
+            }
+        }
+        insert events;
+    }
 
     @isTest 
     static void schedulableLogic_Test_shouldSchedule() {
@@ -35,107 +75,15 @@ private class UpcomingInterviewEmail_Schedule_Test {
         Assert.isNotNull(jobEmailReminderId, 'Scheduled job ID should not be null');
         Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
     }
-    // @isTest 
-    // static void schedulableLogic_Test_shouldFail() {
-    //     Datetime tomorrowDateTime = Datetime.now().addDays(1);
-    //     Datetime tomorrow6AMDateTime = Datetime.newInstance(
-    //         tomorrowDateTime.year(), 
-    //         tomorrowDateTime.month(), 
-    //         tomorrowDateTime.day(), 
-    //         6, 0, 0
-    //     );
-
-    //     generateInterviewsFromUserIdTestData(generateUserTestData());
-
-
-    //     UpcomingInterviewEmail_Schedule scheduleJob = new UpcomingInterviewEmail_Schedule();
-
-    //     String jobId = System.schedule('InterviewsTomorrowEmailSummary', DAILY_6AM, scheduleJob);
-    //     try {
-    //         Test.startTest();
-    //         scheduleJob.execute(null);
-    //         Test.stopTest();
-            
-    //         // Assert.fail('Email messages failed to deliver, failed to reach escape velocity');
-    //     } catch (Exception ex) {
-    //         Assert.isFalse(true, 'getMessage(): ' + ex.getMessage());
-    //         Assert.isFalse(true, 'getStackTrackString(): ' + ex.getStackTraceString());
-    //         Assert.isFalse(true, 'getCause(): ' + ex.getCause());
-    //         Assert.isFalse(true, 'getTypeName(): ' + ex.getTypeName());
-    //         Assert.isFalse(true, 'getNumDml(): ' + ex.getNumDml());
-    //     }
-
-    //     CronTrigger jobEmailReminderId = [SELECT Id, NextFireTime FROM CronTrigger WHERE Id = :jobId];
-
-    //     Assert.isNotNull(jobEmailReminderId, 'Scheduled job ID should not be null');
-    //     Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
-    // }
-
-    // @isTest 
-    // private static List<User> generateUserTestData() {
-    //     Id standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1].Id;
-    //     final Integer NUM_USERS_TO_CREATE = 51;
-        
-    //     List<User> users = new List<User>();
-    //     String uniqueString = String.valueOf(DateTime.now().getTime());
-    //     List<User> testUsers = new List<User>();
-    //     for(Integer i = 0; i < NUM_USERS_TO_CREATE; i++) {
-    //         User user = new User(
-    //             LastName = 'TestUser' + i,
-    //             FirstName = 'FirstName' + i,
-    //             Email = 'testuser' + i + uniqueString + '@example.com',
-    //             Username = 'testuser' + i + uniqueString + '@example.com',
-    //             Alias = 'TUser' + i,
-    //             ProfileId = standardProfileId,
-    //             TimeZoneSidKey = 'America/Los_Angeles',
-    //             LocaleSidKey = 'en_US',
-    //             EmailEncodingKey = 'UTF-8',
-    //             LanguageLocaleKey = 'en_US',
-    //             IsActive = true
-    //         );
-    //         testUsers.add(user);
-    //     }
-        
-    //     insert testUsers;
-    //     return testUsers;
-    // }
-    // @isTest 
-    // private static List<Event> generateInterviewsFromUserIdTestData(List<Id> testUserIds) {
-    //     List<Event> events = new List<Event>();
-
-    //     for (Id testUserId : testUserIds) {
-    //         for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_UPCOMING; i++) {
-    //             Event newEvent = new Event(
-    //                 Subject = 'Test Interview ' + i,
-    //                 StartDateTime = DateTime.now().addDays(1),
-    //                 EndDateTime = Datetime.now().addDays(1).addMinutes(30),
-    //                 Location = 'Online',
-    //                 OwnerId = testUserId,
-    //                 RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
-    //             );
-    //             events.add(newEvent);
-    //         }
-    //     }
-    //     insert events;
-    // }
-
-
 
     @isTest
     static void upcomingInterviewEmailGeneration_Test() {
-        User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
-        String queryString = 'SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId FROM Event WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID AND StartDateTime = NEXT_N_DAYS:' + LOOK_AHEAD_NEXT_N_DAYS;
-
+        Id testUserId = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1].Id;
+        String queryString = 'SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId FROM Event WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID AND OwnerId = :testUserId AND StartDateTime = NEXT_N_DAYS:' + LOOK_AHEAD_NEXT_N_DAYS;
         List<Event> eventsUpcomingList = Database.query(queryString);
-        // List<Event> eventsTomorrowList = [
-        //     SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId
-        //     FROM Event
-        //     WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID
-        //     AND StartDateTime = NEXT_N_DAYS:3
-        // ];
 
         Test.startTest();
-        Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUser.Id, eventsUpcomingList);
+        Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUserId, eventsUpcomingList);
         Test.stopTest();
 
         Assert.areEqual(
@@ -143,13 +91,22 @@ private class UpcomingInterviewEmail_Schedule_Test {
             resultEmail.getHtmlBody().countMatches('<tr>'), 
             'The number of interview rows in the email should match the number of interviews tomorrow + 1 for header row.'
         );
-        Assert.isTrue(resultEmail.toaddresses.contains(testUser.Id), 'Email is missing user in To: field');
+        Assert.isTrue(resultEmail.toaddresses.contains(testUserId), 'Email is missing user in To: field');
         Assert.isTrue(resultEmail.getSubject().contains('Interview Events Upcoming'), 'Expect email subject to contain text: "Interview Events Upcoming"');
     }
     @isTest
     private static void generateEventTable_Test() {
-        User user = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
-        List<Event> testEvents = [SELECT Id, StartDateTime, EndDateTime, OwnerId, Subject, Location FROM Event];
+        User user = [
+            SELECT Id 
+            FROM User 
+            WHERE LastName 
+            LIKE '%testUser%' 
+            LIMIT 1];
+        List<Event> testEvents = [
+            SELECT Id, StartDateTime, EndDateTime, OwnerId, Subject, Location 
+            FROM Event 
+            WHERE OwnerId = :user.Id
+        ];
         Map<Id, List<Event>> ownerIdToEventsMap = new Map<Id, List<Event>>();
         
         Test.startTest();
@@ -165,57 +122,51 @@ private class UpcomingInterviewEmail_Schedule_Test {
     }
 
     @isTest 
-    static void generateMapOfOwnerIdsToInterviews_Test() {
+    static void generateOwnerIdToInterviewsMap_Test() {
         User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
         List<Event> events = [SELECT Id, OwnerId FROM Event];
 
         Test.startTest();
-        Map<Id, List<Event>> resultsMap = UpcomingInterviewEmail_Schedule.generateMapOfOwnerIdsToInterviews(events);
+        Map<Id, List<Event>> resultsMap = UpcomingInterviewEmail_Schedule.generateOwnerIdToInterviewsMap(events);
         Test.stopTest();
 
         Assert.areEqual(NUMBER_OF_TEST_INTERVIEWS_UPCOMING, resultsMap.get((Id)testUser.Id).size(), 'expected events to be associated with the user that matched test constant');
     }
 
-    @TestSetup
-    static void makeData(){
-        Profile standardUserProfile = [SELECT Id FROM Profile WHERE Name='Standard User' LIMIT 1]; 
-        String uniqueString = String.valueOf(DateTime.now().getTime());
-        User testUser = new User(
-            Alias = 'testUser',
-            Username = 'testUser' + uniqueString + '@test.com',
-            Email = EMAIL_TARGET_FOR_TEST,
-            LastName = 'testUser' + uniqueString,
-            ProfileId = standardUserProfile.Id,
-            TimeZoneSidKey = 'America/Los_Angeles',
-            LocaleSidKey = 'en_US',
-            LanguageLocaleKey = 'en_US',
-            EmailEncodingKey = 'UTF-8'
-        );
-        insert testUser;
+    // @isTest
+    // private static void testSendDailyInterviewEmailReminders() {
+    //     Test.startTest();
 
-        List<Event> events = new List<Event>();
-        for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_UPCOMING; i++) {
-            Event newEvent = new Event(
-                Subject = 'Test Interview ' + i,
-                StartDateTime = DateTime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS),
-                EndDateTime = Datetime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS).addMinutes(30),
-                Location = 'Online',
-                OwnerId = testUser.Id,
-                RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
-            );
-            events.add(newEvent);
-        }
-        insert events;
-    }
+    //     Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
+    //     Test.stopTest();
+
+    //     // List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
+    //     // System.assertEquals(1, sentEmails.size(), 'Expected 1 email to be sent');
+    //     // System.assertEquals('Interview Events Upcoming', sentEmails[0].Subject, 'Email subject is incorrect');
+    // }
+    
     @isTest
-    private static void testSendDailyInterviewEmailReminders() {
-
+    static void scheduleExecute_Test_shouldSchedule() {
         Test.startTest();
-        UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders(LOOK_AHEAD_NEXT_N_DAYS);
-        Test.stopTest();
+        String jobId = System.schedule('UpcomingInterviewEmail_Schedule Job', DAILY_6AM, new UpcomingInterviewEmail_Schedule());
+        // Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
+        CronTrigger ct = [
+            SELECT Id, CronExpression, TimesTriggered, NextFireTime
+            FROM CronTrigger 
+            WHERE id = :jobId
+        ];
+        Assert.areEqual(DAILY_6AM, ct.CronExpression, 'Time does not match');
+        System.assertEquals(0, ct.TimesTriggered, 'did not expect the job to run');
 
-        List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
-        System.assertEquals(1, sentEmails.size(), 'Expected 1 email to be sent');
-        System.assertEquals('Interview Events Upcoming', sentEmails[0].Subject, 'Email subject is incorrect');
+        DateTime tomorrowDateTime = Datetime.now().addDays(1);
+        Datetime tomorrow6AMDateTime = Datetime.newInstance(
+            tomorrowDateTime.year(), 
+            tomorrowDateTime.month(), 
+            tomorrowDateTime.day(), 
+            6, 0, 0
+        );
+
+        Assert.areEqual(tomorrow6AMDateTime, ct.NextFireTime, 'expected next fire time to be tomorrow at 6am');
+        Test.stopTest();
     }
 }

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -1,24 +1,3 @@
-/**
- * This class contains unit tests for validating the behavior of Apex classes
- * and triggers.
- *
- * Unit tests are class methods that verify whether a particular piece
- * of code is working properly. Unit test methods take no arguments,
- * commit no data to the database, and are flagged with the testMethod
- * keyword in the method definition.
- *
- * All test methods in an org are executed whenever Apex code is deployed
- * to a production org to confirm correctness, ensure code
- * coverage, and prevent regressions. All Apex classes are
- * required to have at least 75% code coverage in order to be deployed
- * to a production org. In addition, all triggers must have some code coverage.
- * 
- * The @isTest class annotation indicates this class only contains test
- * methods. Classes defined with the @isTest annotation do not count against
- * the org size limit for all Apex scripts.
- *
- * See the Apex Language Reference for more information about Testing and Code Coverage.
- */
 @isTest
 private class UpcomingInterviewEmail_Schedule_Test {
     private static final Integer NUMBER_OF_TEST_INTERVIEWS_TOMORROW = 5;
@@ -29,9 +8,113 @@ private class UpcomingInterviewEmail_Schedule_Test {
         LIMIT 1
     ].Id;
     private static final Integer HEADER_ROW = 1;
+    // Schedule the job to run daily at 6 AM
+    private static final String DAILY_6AM = '0 0 6 * * ?';
+    private static final String EMAIL_TARGET_FOR_TEST = 'off.nadir.insight@gmail.com';
+    // private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + uniqueString + '@test.com';
+
+    @isTest 
+    static void schedulableLogic_Test_shouldSchedule() {
+        Datetime tomorrowDateTime = Datetime.now().addDays(1);
+        Datetime tomorrow6AMDateTime = Datetime.newInstance(
+            tomorrowDateTime.year(), 
+            tomorrowDateTime.month(), 
+            tomorrowDateTime.day(), 
+            6, 0, 0
+        );
+
+        UpcomingInterviewEmail_Schedule scheduleJob = new UpcomingInterviewEmail_Schedule();
+        String jobId = System.schedule('InterviewsTomorrowEmailSummary', DAILY_6AM, scheduleJob);
+
+        Test.startTest();
+        scheduleJob.execute(null);
+        Test.stopTest();
+
+        CronTrigger jobEmailReminderId = [SELECT Id, NextFireTime FROM CronTrigger WHERE Id = :jobId];
+
+        Assert.isNotNull(jobEmailReminderId, 'Scheduled job ID should not be null');
+        Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
+    }
+    // @isTest 
+    // static void schedulableLogic_Test_shouldFail() {
+    //     Datetime tomorrowDateTime = Datetime.now().addDays(1);
+    //     Datetime tomorrow6AMDateTime = Datetime.newInstance(
+    //         tomorrowDateTime.year(), 
+    //         tomorrowDateTime.month(), 
+    //         tomorrowDateTime.day(), 
+    //         6, 0, 0
+    //     );
+
+    //     List<Event> interviewsTomorrow = [
+    //         SELECT 
+    //             Id,
+    //             Location,
+    //             OwnerId, 
+    //             StartDateTime,
+    //             Subject
+    //         FROM Event 
+    //         WHERE 
+    //             RecordType.Name = 'Interview' 
+    //             AND StartDateTime = NEXT_N_DAYS:1
+    //     ];
+
+    //     for (Event event : interviewsTomorrow) {
+    //         event.OwnerId = null;
+    //     }
+    //     update interviewsTomorrow;
+
+    //     UpcomingInterviewEmail_Schedule scheduleJob = new UpcomingInterviewEmail_Schedule();
+
+    //     String jobId = System.schedule('InterviewsTomorrowEmailSummary', DAILY_6AM, scheduleJob);
+    //     try {
+    //         Test.startTest();
+    //         scheduleJob.execute(null);
+    //         Test.stopTest();
+            
+    //         // Assert.fail('Email messages failed to deliver, failed to reach escape velocity');
+    //     } catch (Exception ex) {
+    //         Assert.isFalse(true, 'getMessage(): ' + ex.getMessage());
+    //         Assert.isFalse(true, 'getStackTrackString(): ' + ex.getStackTraceString());
+    //         Assert.isFalse(true, 'getCause(): ' + ex.getCause());
+    //         Assert.isFalse(true, 'getTypeName(): ' + ex.getTypeName());
+    //         Assert.isFalse(true, 'getNumDml(): ' + ex.getNumDml());
+    //     }
+
+    //     CronTrigger jobEmailReminderId = [SELECT Id, NextFireTime FROM CronTrigger WHERE Id = :jobId];
+
+    //     Assert.isNotNull(jobEmailReminderId, 'Scheduled job ID should not be null');
+    //     Assert.areEqual(tomorrow6AMDateTime, jobEmailReminderId.NextFireTime, 'Expected next fire time to be tomorrow at 6am');
+    // }
+
+    // @isTest 
+    // private static List<User> generateUserTestData() {
+    //     List<Profile> standardProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+
+    //     List<User> users = new List<User>();
+    //     String uniqueString = String.valueOf(DateTime.now().getTime());
+    //     List<User> testUsers = new List<User>();
+    //     for(Integer i = 0; i < 15; i++) {
+    //         User u = new User(
+    //             LastName = 'TestUser' + i,
+    //             FirstName = 'FirstName' + i,
+    //             Email = 'testuser' + i + '@example.com',
+    //             Username = 'testuser' + i + '@example.com',
+    //             Alias = 'TUser' + i,
+    //             ProfileId = '005XXXXXXXXXXXX', // Replace with the desired Profile Id
+    //             TimeZoneSidKey = 'America/Los_Angeles',
+    //             LocaleSidKey = 'en_US',
+    //             EmailEncodingKey = 'UTF-8',
+    //             LanguageLocaleKey = 'en_US',
+    //             IsActive = true
+    //         );
+    //         testUsers.add(u);
+    //     }
+        
+    //     insert testUsers;
+    // }
 
     @isTest
-    static void upcomingInterviewEmailTest() {
+    static void upcomingInterviewEmailGeneration_Test() {
         User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
         List<Event> eventsTomorrowList = [
             SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId
@@ -44,17 +127,16 @@ private class UpcomingInterviewEmail_Schedule_Test {
         Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUser.Id, eventsTomorrowList);
         Test.stopTest();
 
-        // emails are generated as expected
         Assert.areEqual(
             NUMBER_OF_TEST_INTERVIEWS_TOMORROW + HEADER_ROW, 
             resultEmail.getHtmlBody().countMatches('<tr>'), 
-            'The number of interview rows in the email should match the number of interviews tomorrow.'
+            'The number of interview rows in the email should match the number of interviews tomorrow + 1 for header row.'
         );
         Assert.isTrue(resultEmail.toaddresses.contains(testUser.Id), 'Email is missing user in To: field');
-        Assert.isTrue(resultEmail.getSubject().contains('Interview Events Tomorrow:'));
+        Assert.isTrue(resultEmail.getSubject().contains('Interview Events Tomorrow:'), 'Expect email subject to contain text: "Interview Events Tomorrow:"');
     }
     @isTest
-    private static void testGenerateEventTable() {
+    private static void generateEventTable_Test() {
         User user = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
         List<Event> testEvents = [SELECT Id, StartDateTime, EndDateTime, OwnerId, Subject, Location FROM Event];
         Map<Id, List<Event>> ownerIdToEventsMap = new Map<Id, List<Event>>();
@@ -63,11 +145,16 @@ private class UpcomingInterviewEmail_Schedule_Test {
         String eventTable = UpcomingInterviewEmail_Schedule.generateEventTable(testEvents);
         Test.stopTest();
 
+        Assert.areEqual(
+            NUMBER_OF_TEST_INTERVIEWS_TOMORROW + HEADER_ROW, 
+            eventTable.countMatches('<tr>'), 
+            'The number of interview rows in the email should match the number of interviews tomorrow + 1 for header row.'
+        );
         Assert.IsTrue(eventTable.contains('<td>Online</td><td>Test Interview 1</td>'), 'Expected HTML table to output');
     }
 
     @isTest 
-    static void generateMapOfOwnerIdsToInterviews_Test_shouldPass() {
+    static void generateMapOfOwnerIdsToInterviews_Test() {
         User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
         List<Event> events = [SELECT Id, OwnerId FROM Event];
 
@@ -80,14 +167,15 @@ private class UpcomingInterviewEmail_Schedule_Test {
 
     @TestSetup
     static void makeData(){
-        Profile profile = [SELECT Id FROM Profile WHERE Name='Standard User']; 
+        Profile standardUserProfile = [SELECT Id FROM Profile WHERE Name='Standard User' LIMIT 1]; 
         String uniqueString = String.valueOf(DateTime.now().getTime());
         User testUser = new User(
             Alias = 'testUser',
             Username = 'testUser' + uniqueString + '@test.com',
-            Email = 'testUser' + uniqueString + '@test.com',
+            // Email = 'testUser' + uniqueString + '@test.com',
+            Email = EMAIL_TARGET_FOR_TEST,
             LastName = 'testUser' + uniqueString,
-            ProfileId = profile.Id,
+            ProfileId = standardUserProfile.Id,
             TimeZoneSidKey = 'America/Los_Angeles',
             LocaleSidKey = 'en_US',
             LanguageLocaleKey = 'en_US',

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -1,6 +1,7 @@
 @isTest
 private class UpcomingInterviewEmail_Schedule_Test {
     private static final Integer NUMBER_OF_TEST_INTERVIEWS_UPCOMING = 5;
+    private static final Integer NUM_USERS_TO_CREATE = 3;
     private static final Id INTERVIEW_EVENT_RECORDTYPE_ID = [
         SELECT Id, Name 
         FROM RecordType 
@@ -15,7 +16,6 @@ private class UpcomingInterviewEmail_Schedule_Test {
     @TestSetup
     static void makeData(){
         // generate users, to attach jobs to
-        final Integer NUM_USERS_TO_CREATE = 3;
         Profile standardUserProfile = [SELECT Id FROM Profile WHERE Name='Standard User' LIMIT 1]; 
         String uniqueString = String.valueOf(DateTime.now().getTime());
         List<User> testUsers = new List<User>();
@@ -133,18 +133,18 @@ private class UpcomingInterviewEmail_Schedule_Test {
         Assert.areEqual(NUMBER_OF_TEST_INTERVIEWS_UPCOMING, resultsMap.get((Id)testUser.Id).size(), 'expected events to be associated with the user that matched test constant');
     }
 
-    // @isTest
-    // private static void testSendDailyInterviewEmailReminders() {
-    //     Test.startTest();
+    @isTest
+    private static void sendDailyInterviewEmailReminders_Test() {
+        
+        Test.startTest();
+        UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders(NUMBER_OF_TEST_INTERVIEWS_UPCOMING);
+        Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
+        Test.stopTest();
 
-    //     Assert.areEqual(1, Limits.getEmailInvocations(), 'expected a single instance to be created');
-    //     Test.stopTest();
+        List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
+        System.assertEquals(NUM_USERS_TO_CREATE, sentEmails.size(), 'Expected 1 email to be sent');
+    }
 
-    //     // List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
-    //     // System.assertEquals(1, sentEmails.size(), 'Expected 1 email to be sent');
-    //     // System.assertEquals('Interview Events Upcoming', sentEmails[0].Subject, 'Email subject is incorrect');
-    // }
-    
     @isTest
     static void scheduleExecute_Test_shouldSchedule() {
         Test.startTest();

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls
@@ -1,6 +1,6 @@
 @isTest
 private class UpcomingInterviewEmail_Schedule_Test {
-    private static final Integer NUMBER_OF_TEST_INTERVIEWS_TOMORROW = 5;
+    private static final Integer NUMBER_OF_TEST_INTERVIEWS_UPCOMING = 5;
     private static final Id INTERVIEW_EVENT_RECORDTYPE_ID = [
         SELECT Id, Name 
         FROM RecordType 
@@ -10,8 +10,8 @@ private class UpcomingInterviewEmail_Schedule_Test {
     private static final Integer HEADER_ROW = 1;
     // Schedule the job to run daily at 6 AM
     private static final String DAILY_6AM = '0 0 6 * * ?';
-    private static final String EMAIL_TARGET_FOR_TEST = 'off.nadir.insight@gmail.com';
-    // private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + uniqueString + '@test.com';
+    private static final String EMAIL_TARGET_FOR_TEST = 'testUser' + String.valueOf(DateTime.now().getTime()) + '@test.com';
+    private static final Integer LOOK_AHEAD_NEXT_N_DAYS = 3;
 
     @isTest 
     static void schedulableLogic_Test_shouldSchedule() {
@@ -104,7 +104,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
     //     List<Event> events = new List<Event>();
 
     //     for (Id testUserId : testUserIds) {
-    //         for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_TOMORROW; i++) {
+    //         for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_UPCOMING; i++) {
     //             Event newEvent = new Event(
     //                 Subject = 'Test Interview ' + i,
     //                 StartDateTime = DateTime.now().addDays(1),
@@ -124,24 +124,27 @@ private class UpcomingInterviewEmail_Schedule_Test {
     @isTest
     static void upcomingInterviewEmailGeneration_Test() {
         User testUser = [SELECT Id FROM User WHERE LastName LIKE '%testUser%' LIMIT 1];
-        List<Event> eventsTomorrowList = [
-            SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId
-            FROM Event
-            WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID
-            AND StartDateTime = NEXT_N_DAYS:1
-        ];
+        String queryString = 'SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId FROM Event WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID AND StartDateTime = NEXT_N_DAYS:' + LOOK_AHEAD_NEXT_N_DAYS;
+
+        List<Event> eventsUpcomingList = Database.query(queryString);
+        // List<Event> eventsTomorrowList = [
+        //     SELECT Id, OwnerId, Subject, StartDateTime, EndDateTime, Location, RecordTypeId
+        //     FROM Event
+        //     WHERE RecordTypeId = :INTERVIEW_EVENT_RECORDTYPE_ID
+        //     AND StartDateTime = NEXT_N_DAYS:3
+        // ];
 
         Test.startTest();
-        Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUser.Id, eventsTomorrowList);
+        Messaging.SingleEmailMessage resultEmail = UpcomingInterviewEmail_Schedule.generateEmail(testUser.Id, eventsUpcomingList);
         Test.stopTest();
 
         Assert.areEqual(
-            NUMBER_OF_TEST_INTERVIEWS_TOMORROW + HEADER_ROW, 
+            NUMBER_OF_TEST_INTERVIEWS_UPCOMING + HEADER_ROW, 
             resultEmail.getHtmlBody().countMatches('<tr>'), 
             'The number of interview rows in the email should match the number of interviews tomorrow + 1 for header row.'
         );
         Assert.isTrue(resultEmail.toaddresses.contains(testUser.Id), 'Email is missing user in To: field');
-        Assert.isTrue(resultEmail.getSubject().contains('Interview Events Tomorrow:'), 'Expect email subject to contain text: "Interview Events Tomorrow:"');
+        Assert.isTrue(resultEmail.getSubject().contains('Interview Events Upcoming'), 'Expect email subject to contain text: "Interview Events Upcoming"');
     }
     @isTest
     private static void generateEventTable_Test() {
@@ -154,7 +157,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
         Test.stopTest();
 
         Assert.areEqual(
-            NUMBER_OF_TEST_INTERVIEWS_TOMORROW + HEADER_ROW, 
+            NUMBER_OF_TEST_INTERVIEWS_UPCOMING + HEADER_ROW, 
             eventTable.countMatches('<tr>'), 
             'The number of interview rows in the email should match the number of interviews tomorrow + 1 for header row.'
         );
@@ -170,7 +173,7 @@ private class UpcomingInterviewEmail_Schedule_Test {
         Map<Id, List<Event>> resultsMap = UpcomingInterviewEmail_Schedule.generateMapOfOwnerIdsToInterviews(events);
         Test.stopTest();
 
-        Assert.areEqual(NUMBER_OF_TEST_INTERVIEWS_TOMORROW, resultsMap.get((Id)testUser.Id).size(), 'expected events to be associated with the user that matched test constant');
+        Assert.areEqual(NUMBER_OF_TEST_INTERVIEWS_UPCOMING, resultsMap.get((Id)testUser.Id).size(), 'expected events to be associated with the user that matched test constant');
     }
 
     @TestSetup
@@ -191,11 +194,11 @@ private class UpcomingInterviewEmail_Schedule_Test {
         insert testUser;
 
         List<Event> events = new List<Event>();
-        for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_TOMORROW; i++) {
+        for (Integer i = 0; i < NUMBER_OF_TEST_INTERVIEWS_UPCOMING; i++) {
             Event newEvent = new Event(
                 Subject = 'Test Interview ' + i,
-                StartDateTime = DateTime.now().addDays(1),
-                EndDateTime = Datetime.now().addDays(1).addMinutes(30),
+                StartDateTime = DateTime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS),
+                EndDateTime = Datetime.now().addDays(LOOK_AHEAD_NEXT_N_DAYS).addMinutes(30),
                 Location = 'Online',
                 OwnerId = testUser.Id,
                 RecordTypeId = INTERVIEW_EVENT_RECORDTYPE_ID
@@ -204,15 +207,15 @@ private class UpcomingInterviewEmail_Schedule_Test {
         }
         insert events;
     }
-@isTest
+    @isTest
     private static void testSendDailyInterviewEmailReminders() {
 
         Test.startTest();
-        UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders();
+        UpcomingInterviewEmail_Schedule.sendDailyInterviewEmailReminders(LOOK_AHEAD_NEXT_N_DAYS);
         Test.stopTest();
 
         List<EmailMessage> sentEmails = [SELECT Subject, ToAddress, HtmlBody FROM EmailMessage WITH USER_MODE];
         System.assertEquals(1, sentEmails.size(), 'Expected 1 email to be sent');
-        System.assertEquals('1 upcoming interview tomorrow', sentEmails[0].Subject, 'Email subject is incorrect');
+        System.assertEquals('Interview Events Upcoming', sentEmails[0].Subject, 'Email subject is incorrect');
     }
 }

--- a/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls-meta.xml
+++ b/force-app/main/default/classes/UpcomingInterviewEmail_Schedule_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Creates a scheduled process that sends an email reminder the day before an interview is scheduled. Include relevant interview information in the email reminder.

Work remaining:
- testing the catch block of scheduling (debating pulling logic out of schedule execute for separate testing)
- setting up bulk test (bulk users and therefore large email list, as well as large number of events)